### PR TITLE
feat: cross-platform CI — Linux/macOS/Windows matrix + platform-gate evdev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,44 @@ permissions:
   contents: write
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  release:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-22.04
+            args: ""
+          - platform: macos-latest
+            args: "--target aarch64-apple-darwin"
+          - platform: macos-latest
+            args: "--target x86_64-apple-darwin"
+          - platform: windows-latest
+            args: ""
+
+    runs-on: ${{ matrix.platform }}
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -21,68 +53,17 @@ jobs:
             libayatana-appindicator3-dev patchelf \
             libevdev-dev libudev-dev
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: latest
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
-
-      - name: Install frontend deps
+      - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: "k0 ${{ github.ref_name }}"
-          releaseBody: "Keyboard overlay release ${{ github.ref_name }}"
+          releaseName: "k0 __VERSION__"
+          releaseBody: "See assets below to download and install."
           releaseDraft: false
           prerelease: false
-
-  build-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: latest
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
-
-      - name: Install frontend deps
-        run: pnpm install --frozen-lockfile
-
-      - name: Build Tauri app (universal)
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tagName: ${{ github.ref_name }}
-          releaseName: "k0 ${{ github.ref_name }}"
-          releaseBody: "Keyboard overlay release ${{ github.ref_name }}"
-          releaseDraft: false
-          prerelease: false
-          args: --target universal-apple-darwin
+          generateReleaseNotes: true
+          args: ${{ matrix.args }}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,11 +23,13 @@ tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-positioner = "2.0.0"
-evdev = "0.12"
 tauri-plugin-log = "2"
 log = "0.4.22"
-libc = "0.2.184"
 
 
 [target.'cfg(target_os = "macos")'.dependencies]
 io-kit-sys = "0.4.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+evdev = "0.12"
+libc = "0.2.184"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,6 @@
-use evdev::{Device, EventType, InputEvent};
 use log::info;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::os::unix::io::AsRawFd;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use tauri::{Emitter, Manager};
 use tauri_plugin_log::{Target, TargetKind};
@@ -34,7 +32,6 @@ struct LayerEvent { layer: String }
 pub struct DeviceInfo {
     pub path: String,
     pub name: String,
-    /// Physical device ID from sysfs (Uniq field) — same value = same physical device
     pub uniq: String,
 }
 
@@ -47,33 +44,41 @@ struct LayoutData {
 }
 
 type SharedLayout = Arc<RwLock<LayoutData>>;
-/// Set of currently-captured device paths. Thread checks membership to know when to stop.
-type ActiveDevices = Arc<Mutex<HashSet<String>>>;
+type ActiveDevices = Arc<Mutex<std::collections::HashSet<String>>>;
 
 #[tauri::command]
 fn list_devices() -> Vec<DeviceInfo> {
-    let mut devices = Vec::new();
-    if let Ok(entries) = std::fs::read_dir("/dev/input") {
-        let mut paths: Vec<_> = entries
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_name().to_str().map(|n| n.starts_with("event")).unwrap_or(false))
-            .collect();
-        paths.sort_by_key(|e| e.file_name());
-        for entry in paths {
-            let path = entry.path();
-            if let Ok(dev) = Device::open(&path) {
-                if dev.supported_keys().map(|k| k.iter().count() > 5).unwrap_or(false) {
-                    devices.push(DeviceInfo {
-                        path: path.to_string_lossy().to_string(),
-                        name: dev.name().unwrap_or("Unknown").to_string(),
-                        uniq: dev.unique_name().unwrap_or("").to_string(),
-                    });
+    #[cfg(target_os = "linux")]
+    {
+        use evdev::Device;
+        let mut devices = Vec::new();
+        if let Ok(entries) = std::fs::read_dir("/dev/input") {
+            let mut paths: Vec<_> = entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_str().map(|n| n.starts_with("event")).unwrap_or(false))
+                .collect();
+            paths.sort_by_key(|e| e.file_name());
+            for entry in paths {
+                let path = entry.path();
+                if let Ok(dev) = Device::open(&path) {
+                    if dev.supported_keys().map(|k| k.iter().count() > 5).unwrap_or(false) {
+                        devices.push(DeviceInfo {
+                            path: path.to_string_lossy().to_string(),
+                            name: dev.name().unwrap_or("Unknown").to_string(),
+                            uniq: dev.unique_name().unwrap_or("").to_string(),
+                        });
+                    }
                 }
             }
         }
+        info!("Found {} keyboard devices", devices.len());
+        devices
     }
-    info!("Found {} keyboard devices", devices.len());
-    devices
+    #[cfg(not(target_os = "linux"))]
+    {
+        info!("list_devices: evdev not available on this platform");
+        vec![]
+    }
 }
 
 #[tauri::command]
@@ -101,8 +106,6 @@ fn update_layout(
     );
 }
 
-/// Start capturing from one or more /dev/input/eventN paths simultaneously.
-/// Replaces any previously active capture session.
 #[tauri::command]
 fn start_capture(
     paths: Vec<String>,
@@ -110,114 +113,112 @@ fn start_capture(
     active: tauri::State<ActiveDevices>,
     app: tauri::AppHandle,
 ) -> Result<Vec<String>, String> {
-    // Replace active set — old threads will see their path gone and exit
-    let mut active_set = active.lock().unwrap();
-    active_set.clear();
-    let mut started = Vec::new();
+    #[cfg(target_os = "linux")]
+    {
+        use evdev::{Device, EventType, InputEvent};
+        use std::os::unix::io::AsRawFd;
 
-    for path in paths {
-        let mut device = match Device::open(&path) {
-            Ok(d) => d,
-            Err(e) => { log::warn!("Cannot open {}: {e}", path); continue; }
-        };
-        if let Err(e) = device.grab() {
-            log::warn!("Cannot grab {}: {e} (may already be grabbed)", path);
-        }
-        active_set.insert(path.clone());
-        started.push(path.clone());
-        info!("Capturing from {}", path);
+        let mut active_set = active.lock().unwrap();
+        active_set.clear();
+        let mut started = Vec::new();
 
-        let shared = Arc::clone(shared.inner());
-        let active = Arc::clone(active.inner());
-        let app = app.clone();
-
-        std::thread::spawn(move || {
-            info!("evdev listener started on {}", path);
-            let mut hold_timers: HashMap<u16, std::time::Instant> = HashMap::new();
-            let fd = device.as_raw_fd();
-
-            loop {
-                if !active.lock().unwrap().contains(&path) {
-                    info!("Stopping capture of {}", path);
-                    break;
-                }
-
-                // Poll the fd with a 50ms timeout so hold timers are checked
-                // even when no keys are being pressed.
-                let mut pfd = libc::pollfd { fd, events: libc::POLLIN, revents: 0 };
-                let poll_ret = unsafe { libc::poll(&mut pfd as *mut _, 1, 50) };
-                if poll_ret < 0 {
-                    log::error!("poll error on {}: {}", path, std::io::Error::last_os_error());
-                    break;
-                }
-
-                // Always check timers — even if no event arrived this tick
-                {
-                    let data = shared.read().unwrap();
-                    let tapping_term = std::time::Duration::from_millis(data.tapping_term_ms);
-                    for (&pos, &pressed_at) in &hold_timers {
-                        if pressed_at.elapsed() >= tapping_term {
-                            if let Some(layer) = data.pos_to_layer.get(&pos) {
-                                let _ = app.emit("layer-event", LayerEvent { layer: layer.clone() });
-                            }
-                        }
-                    }
-                }
-                hold_timers.retain(|&pos, pressed_at| {
-                    let data = shared.read().unwrap();
-                    let tapping_term = std::time::Duration::from_millis(data.tapping_term_ms);
-                    let fired = pressed_at.elapsed() >= tapping_term && data.pos_to_layer.contains_key(&pos);
-                    !fired
-                });
-
-                // Only read events if the fd is ready
-                if poll_ret == 0 || (pfd.revents & libc::POLLIN) == 0 {
-                    continue;
-                }
-
-                let events: Vec<InputEvent> = match device.fetch_events() {
-                    Ok(it) => it.collect(),
-                    Err(e) => { log::error!("evdev read error on {}: {e}", path); break; }
-                };
-
-                for ev in events {
-                    if ev.event_type() != EventType::KEY { continue; }
-                    let code = ev.code();
-                    let value = ev.value(); // 0=release, 1=press, 2=repeat
-                    if value == 2 { continue; } // ignore autorepeat
-                    let pressed = value == 1;
-
-                    info!("evdev [{}]: code={} pressed={}", path, code, pressed);
-                    let data = shared.read().unwrap();
-                    if let Some(&pos) = data.code_to_pos.get(&code) {
-                        let _ = app.emit("key-event", KeyEvent { pos, pressed });
-
-                        if data.pos_to_layer.contains_key(&pos) {
-                            if pressed {
-                                hold_timers.insert(pos, std::time::Instant::now());
-                            } else {
-                                hold_timers.remove(&pos);
-                                let _ = app.emit("layer-event", LayerEvent { layer: data.default_layer.clone() });
-                            }
-                        }
-                    } else {
-                        info!("evdev: unmapped code {} on {}", code, path);
-                    }
-                }
+        for path in paths {
+            let mut device = match Device::open(&path) {
+                Ok(d) => d,
+                Err(e) => { log::warn!("Cannot open {}: {e}", path); continue; }
+            };
+            if let Err(e) = device.grab() {
+                log::warn!("Cannot grab {}: {e} (may already be grabbed)", path);
             }
-        });
-    }
+            active_set.insert(path.clone());
+            started.push(path.clone());
+            info!("Capturing from {}", path);
 
-    Ok(started)
+            let shared = Arc::clone(shared.inner());
+            let active = Arc::clone(active.inner());
+            let app = app.clone();
+
+            std::thread::spawn(move || {
+                info!("evdev listener started on {}", path);
+                let mut hold_timers: HashMap<u16, std::time::Instant> = HashMap::new();
+                let fd = device.as_raw_fd();
+
+                loop {
+                    if !active.lock().unwrap().contains(&path) {
+                        info!("Stopping capture of {}", path);
+                        break;
+                    }
+
+                    let mut pfd = libc::pollfd { fd, events: libc::POLLIN, revents: 0 };
+                    let poll_ret = unsafe { libc::poll(&mut pfd as *mut _, 1, 50) };
+                    if poll_ret < 0 {
+                        log::error!("poll error on {}: {}", path, std::io::Error::last_os_error());
+                        break;
+                    }
+
+                    {
+                        let data = shared.read().unwrap();
+                        let tapping_term = std::time::Duration::from_millis(data.tapping_term_ms);
+                        for (&pos, &pressed_at) in &hold_timers {
+                            if pressed_at.elapsed() >= tapping_term {
+                                if let Some(layer) = data.pos_to_layer.get(&pos) {
+                                    let _ = app.emit("layer-event", LayerEvent { layer: layer.clone() });
+                                }
+                            }
+                        }
+                    }
+                    hold_timers.retain(|&pos, pressed_at| {
+                        let data = shared.read().unwrap();
+                        let tapping_term = std::time::Duration::from_millis(data.tapping_term_ms);
+                        let fired = pressed_at.elapsed() >= tapping_term && data.pos_to_layer.contains_key(&pos);
+                        !fired
+                    });
+
+                    if poll_ret == 0 || (pfd.revents & libc::POLLIN) == 0 {
+                        continue;
+                    }
+
+                    let events: Vec<InputEvent> = match device.fetch_events() {
+                        Ok(it) => it.collect(),
+                        Err(e) => { log::error!("evdev read error on {}: {e}", path); break; }
+                    };
+
+                    for ev in events {
+                        if ev.event_type() != EventType::KEY { continue; }
+                        let code = ev.code();
+                        let value = ev.value();
+                        if value == 2 { continue; }
+                        let pressed = value == 1;
+
+                        let data = shared.read().unwrap();
+                        if let Some(&pos) = data.code_to_pos.get(&code) {
+                            let _ = app.emit("key-event", KeyEvent { pos, pressed });
+                            if data.pos_to_layer.contains_key(&pos) {
+                                if pressed {
+                                    hold_timers.insert(pos, std::time::Instant::now());
+                                } else {
+                                    hold_timers.remove(&pos);
+                                    let _ = app.emit("layer-event", LayerEvent { layer: data.default_layer.clone() });
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+        Ok(started)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (paths, shared, active, app);
+        Ok(vec![])
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let shared: SharedLayout = Arc::new(RwLock::new(LayoutData {
-        default_layer: "Base".into(),
-        ..Default::default()
-    }));
-    let active: ActiveDevices = Arc::new(Mutex::new(HashSet::new()));
+    let layout: SharedLayout = Arc::new(RwLock::new(LayoutData::default()));
+    let active: ActiveDevices = Arc::new(Mutex::new(std::collections::HashSet::new()));
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -226,12 +227,11 @@ pub fn run() {
             tauri_plugin_log::Builder::new()
                 .targets([
                     Target::new(TargetKind::Stdout),
-                    Target::new(TargetKind::LogDir { file_name: None }),
                     Target::new(TargetKind::Webview),
                 ])
                 .build(),
         )
-        .manage(shared)
+        .manage(layout)
         .manage(active)
         .setup(|app: &mut tauri::App| {
             request_input_access();


### PR DESCRIPTION
## Changes

- Rewrites `release.yml` as a single matrix job covering `ubuntu-22.04`, `macos-latest` (arm64 + x86_64), and `windows-latest`
- Uses `tauri-action __VERSION__` token so release name always reflects `tauri.conf.json` version
- Enables `generateReleaseNotes` for automatic changelog from commits
- Moves `evdev` + `libc` to `[target.'cfg(target_os = "linux")'.dependencies]` in `Cargo.toml`
- Gates all evdev/libc Rust code with `#[cfg(target_os = "linux")]` — macOS/Windows compile and run cleanly, returning an empty device list gracefully