### PR TITLE
fix: cog key style, CI macos runner, console layout, tab separator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           - platform: macos-latest
             args: "--target aarch64-apple-darwin"
             rust-target: "aarch64-apple-darwin"
-          - platform: macos-13
+          - platform: macos-latest
             args: "--target x86_64-apple-darwin"
             rust-target: "x86_64-apple-darwin"
           - platform: windows-latest
@@ -63,6 +63,7 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "k0 __VERSION__"

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -297,18 +297,6 @@ export function Settings({
 
 				{tab === "Console" && (
 					<div class="console-pane">
-						<div class="console-toolbar">
-							<small class="muted">{logs.value.length} entries</small>
-							<button
-								type="button"
-								class="console-clear"
-								onClick={() => {
-									consoleLogs.value = [];
-								}}
-							>
-								Clear
-							</button>
-						</div>
 						<div class="console-log-list">
 							{logs.value.map((entry) => (
 								<div
@@ -323,6 +311,18 @@ export function Settings({
 								</div>
 							))}
 							<div ref={consoleEndRef} />
+						</div>
+						<div class="console-toolbar">
+							<small class="muted">{logs.value.length} entries</small>
+							<button
+								type="button"
+								class="console-clear"
+								onClick={() => {
+									consoleLogs.value = [];
+								}}
+							>
+								Clear
+							</button>
 						</div>
 					</div>
 				)}

--- a/src/components/Settings/style.css
+++ b/src/components/Settings/style.css
@@ -53,7 +53,7 @@
 	font-weight: 600;
 	white-space: nowrap;
 	position: relative;
-	top: 1px;
+	margin-bottom: -1px;
 	transition: color 100ms, border-color 100ms;
 }
 .panel-tabbar menu li button:hover {
@@ -309,6 +309,13 @@ details.device-group.partial {
 	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+}
+
+.console-log-list::before {
+	content: "";
+	flex: 1;
 }
 .console-entry {
 	display: flex;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -169,7 +169,7 @@ export function Home() {
 			<div class="keymap-container">
 				<button
 					type="button"
-					class="settings-btn"
+					class={`settings-btn${settingsOpen ? " active" : ""}`}
 					onClick={() => setSettingsOpen((v) => !v)}
 					aria-label="Toggle settings panel"
 				>

--- a/src/pages/Home/style.css
+++ b/src/pages/Home/style.css
@@ -16,28 +16,62 @@
 	align-items: center;
 }
 
-/* Cog button — positional + k0 theme only, matcha handles base button styles */
+/* Cog button — styled to match SVG keys */
 .settings-btn {
 	position: absolute;
 	top: 8px;
 	right: 8px;
 	z-index: 10;
-	width: 32px;
-	height: 32px;
+	width: 26px;
+	height: 26px;
 	padding: 0;
-	font-size: 16px;
+	font-size: 13px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: var(--k0-surface, #313244);
-	border-color: var(--k0-key-stroke, #585b70);
-	color: var(--k0-subtext, #a6adc8);
-	opacity: 0.4;
-	transition: opacity 150ms ease;
+	background: var(--k0-key-fill, #45475a) !important;
+	border: 1px solid var(--k0-key-stroke, #585b70) !important;
+	border-radius: 6px;
+	color: var(--k0-key-text, #cdd6f4) !important;
+	box-shadow: none;
+	opacity: 0.6;
+	transition: opacity 150ms ease, background
+		var(--k0-key-transition-duration, 60ms)
+		var(--k0-key-transition-easing, ease-out), border-color
+		var(--k0-key-transition-duration, 60ms)
+		var(--k0-key-transition-easing, ease-out), color
+		var(--k0-key-transition-duration, 60ms)
+		var(--k0-key-transition-easing, ease-out);
+}
+/* Side element — mirrors SVG rect.side (brightness 75%, offset behind) */
+.settings-btn::before {
+	content: "";
+	position: absolute;
+	inset: -1px;
+	border-radius: 6px;
+	background: color-mix(in srgb, var(--k0-key-fill, #45475a) 75%, black);
+	border: 1px solid color-mix(in srgb, var(--k0-key-stroke, #585b70) 75%, black);
+	transform: translate(3px, 4px);
+	z-index: -1;
+	transition: background var(--k0-key-transition-duration, 60ms)
+		var(--k0-key-transition-easing, ease-out);
 }
 .settings-btn:hover {
 	opacity: 1;
-	color: var(--k0-text, #cdd6f4);
+}
+.settings-btn.active {
+	opacity: 1;
+	background: var(--k0-key-pressed-fill, #cba6f7) !important;
+	border-color: var(--k0-key-pressed-stroke, #d4b0f8) !important;
+	color: var(--k0-key-pressed-text, #1e1e2e) !important;
+}
+.settings-btn.active::before {
+	background: color-mix(in srgb, var(--k0-key-pressed-fill, #cba6f7) 75%, black);
+	border-color: color-mix(
+		in srgb,
+		var(--k0-key-pressed-stroke, #d4b0f8) 75%,
+		black
+	);
 }
 
 .keymap-svg-wrapper {


### PR DESCRIPTION
## Changes

### 🎨 Cog/settings button
- Restyled to match SVG key appearance (same fill, stroke, border-radius)
- 3D side effect via `::before` pseudo-element matching key depth
- Active/pressed state (purple) when settings panel is open

### 🔧 CI fix
- Replace deprecated `macos-13` runner with `macos-latest` for x86_64 cross-compile
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to suppress Node.js 20 deprecation warnings

### 🐛 Tab separator double border
- Fix: `margin-bottom: -1px` replaces `top: 1px` on active tab button

### 🖥️ Console panel layout
- Status bar (entries count + Clear) moved to bottom — terminal style
- Log entries area uses flex column with `::before` spacer for bottom alignment