### PR TITLE
fix: restore macOS key capture + rename app to "k0"

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -444,6 +444,21 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667fdc068627a2816b9ff831201dd9864249d6ee8d190b9532357f1fc0f61ea7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics 0.21.0",
+ "foreign-types 0.3.2",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
@@ -451,9 +466,9 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "cocoa-foundation",
- "core-foundation",
- "core-graphics",
- "foreign-types",
+ "core-foundation 0.10.0",
+ "core-graphics 0.24.0",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -466,7 +481,7 @@ checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
 dependencies = [
  "bitflags 2.6.0",
  "block",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
  "libc",
  "objc",
@@ -500,13 +515,39 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys 0.8.7",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -516,14 +557,38 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.7.0",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -534,7 +599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "libc",
 ]
 
@@ -897,12 +962,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -915,6 +989,12 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1451,7 +1531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
@@ -1668,7 +1748,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "mach2",
 ]
 
@@ -1786,13 +1866,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "k0-keyboard-overlay"
+name = "k0"
 version = "0.1.0"
 dependencies = [
  "evdev",
  "io-kit-sys",
  "libc",
  "log",
+ "rdev",
  "serde",
  "serde_json",
  "tauri",
@@ -2842,6 +2923,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rdev"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00552ca2dc2f93b84cd7b5581de49549411e4e41d89e1c691bcb93dc4be360c3"
+dependencies = [
+ "cocoa 0.22.0",
+ "core-foundation 0.7.0",
+ "core-foundation-sys 0.7.0",
+ "core-graphics 0.19.2",
+ "lazy_static",
+ "libc",
+ "winapi",
+ "x11",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3305,8 +3402,8 @@ checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
 dependencies = [
  "bytemuck",
  "cfg_aliases 0.2.1",
- "core-graphics",
- "foreign-types",
+ "core-graphics 0.24.0",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2",
@@ -3468,9 +3565,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6682a07cf5bab0b8a2bd20d0a542917ab928b5edb75ebd4eda6b05cbaab872da"
 dependencies = [
  "bitflags 2.6.0",
- "cocoa",
- "core-foundation",
- "core-graphics",
+ "cocoa 0.26.0",
+ "core-foundation 0.10.0",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",
@@ -3661,7 +3758,7 @@ checksum = "8aa13d15daf90230ba26d5a9b4a4612975fa64ce17290cb7f6e0f89bb6997d82"
 dependencies = [
  "android_logger",
  "byte-unit",
- "cocoa",
+ "cocoa 0.26.0",
  "fern",
  "log",
  "objc",
@@ -4036,7 +4133,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d48a05076dd272615d03033bf04f480199f7d1b66a8ac64d75c625fc4a70c06b"
 dependencies = [
- "core-graphics",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dirs",
  "libappindicator",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "k0-keyboard-overlay"
+name = "k0"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]
@@ -11,7 +11,7 @@ edition = "2021"
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
-name = "k0_keyboard_overlay_lib"
+name = "k0_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
@@ -29,6 +29,7 @@ log = "0.4.22"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 io-kit-sys = "0.4.1"
+rdev = "0.5.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = "0.12"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>k0 listens to global keyboard events to display them on the overlay.</string>
+	<key>NSInputMonitoringUsageDescription</key>
+	<string>k0 needs Input Monitoring to read raw key presses and render the live keyboard overlay.</string>
+</dict>
+</plist>

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Required for rdev's CGEventTap to receive global key events -->
+	<key>com.apple.security.device.input-monitoring</key>
+	<true/>
+	<!-- App-sandbox disabled so the global event tap actually fires -->
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,31 +2,93 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
-use tauri::{Emitter, Manager};
+use tauri::Manager;
+#[cfg(target_os = "linux")]
+use tauri::Emitter;
 use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_positioner::{Position, WindowExt};
+
+#[cfg(target_os = "macos")]
+mod macos;
 
 #[cfg(target_os = "macos")]
 extern crate io_kit_sys;
 #[cfg(target_os = "macos")]
 extern "C" {
-    fn IOHIDRequestAccess(access: u32) -> i32;
-    fn AXIsProcessTrusted() -> bool;
+    fn IOHIDRequestAccess(access: u32) -> u8;
+    fn IOHIDCheckAccess(access: u32) -> u32;
+    fn AXIsProcessTrusted() -> u8;
 }
 
+#[cfg(target_os = "macos")]
+const K_IOHID_REQUEST_TYPE_LISTEN_EVENT: u32 = 1;
+
+#[cfg(target_os = "macos")]
 fn request_input_access() {
-    #[cfg(target_os = "macos")]
     unsafe {
-        let _ = IOHIDRequestAccess(1);
-        info!("Accessibility trusted: {}", AXIsProcessTrusted());
+        let granted = IOHIDRequestAccess(K_IOHID_REQUEST_TYPE_LISTEN_EVENT);
+        info!(
+            "IOHIDRequestAccess(ListenEvent) -> {}, AXIsProcessTrusted -> {}",
+            granted != 0,
+            AXIsProcessTrusted() != 0,
+        );
+    }
+}
+
+/// Returns one of: "granted" | "denied" | "unknown" | "unsupported".
+#[tauri::command]
+fn check_input_access() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        let status = unsafe { IOHIDCheckAccess(K_IOHID_REQUEST_TYPE_LISTEN_EVENT) };
+        match status {
+            0 => "granted".to_string(),
+            1 => "denied".to_string(),
+            _ => "unknown".to_string(),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "unsupported".to_string()
+    }
+}
+
+/// Triggers the OS permission prompt on first call; returns updated status.
+#[tauri::command]
+fn request_input_access_cmd() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = unsafe { IOHIDRequestAccess(K_IOHID_REQUEST_TYPE_LISTEN_EVENT) };
+        check_input_access()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "unsupported".to_string()
+    }
+}
+
+#[tauri::command]
+fn open_input_monitoring_settings() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let url = "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent";
+        std::process::Command::new("open")
+            .arg(url)
+            .status()
+            .map_err(|e| format!("failed to open System Settings: {e}"))?;
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("only available on macOS".to_string())
     }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-struct KeyEvent { pos: u16, pressed: bool }
+pub(crate) struct KeyEvent { pub pos: u16, pub pressed: bool }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-struct LayerEvent { layer: String }
+pub(crate) struct LayerEvent { pub layer: String }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct DeviceInfo {
@@ -36,14 +98,14 @@ pub struct DeviceInfo {
 }
 
 #[derive(Default)]
-struct LayoutData {
-    code_to_pos: HashMap<u16, u16>,
-    pos_to_layer: HashMap<u16, String>,
-    default_layer: String,
-    tapping_term_ms: u64,
+pub(crate) struct LayoutData {
+    pub code_to_pos: HashMap<u16, u16>,
+    pub pos_to_layer: HashMap<u16, String>,
+    pub default_layer: String,
+    pub tapping_term_ms: u64,
 }
 
-type SharedLayout = Arc<RwLock<LayoutData>>;
+pub(crate) type SharedLayout = Arc<RwLock<LayoutData>>;
 type ActiveDevices = Arc<Mutex<std::collections::HashSet<String>>>;
 
 #[tauri::command]
@@ -74,9 +136,18 @@ fn list_devices() -> Vec<DeviceInfo> {
         info!("Found {} keyboard devices", devices.len());
         devices
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
     {
-        info!("list_devices: evdev not available on this platform");
+        info!("list_devices: returning synthetic macOS global keyboard");
+        vec![DeviceInfo {
+            path: macos::MACOS_GLOBAL_PATH.to_string(),
+            name: "macOS Global Keyboard".to_string(),
+            uniq: "macos".to_string(),
+        }]
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        info!("list_devices: no capture backend on this platform");
         vec![]
     }
 }
@@ -208,7 +279,17 @@ fn start_capture(
         }
         Ok(started)
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
+    {
+        let mut active_set = active.lock().unwrap();
+        active_set.clear();
+        for p in &paths {
+            active_set.insert(p.clone());
+        }
+        macos::start_capture(app, Arc::clone(shared.inner()));
+        Ok(paths)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         let _ = (paths, shared, active, app);
         Ok(vec![])
@@ -234,13 +315,19 @@ pub fn run() {
         .manage(layout)
         .manage(active)
         .setup(|app: &mut tauri::App| {
+            #[cfg(target_os = "macos")]
             request_input_access();
             let window = app.get_webview_window("main").ok_or_else(|| "no window")?;
             let _ = window.move_window(Position::BottomRight);
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            list_devices, update_layout, start_capture
+            list_devices,
+            update_layout,
+            start_capture,
+            check_input_access,
+            request_input_access_cmd,
+            open_input_monitoring_settings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -1,0 +1,136 @@
+use log::{info, warn};
+use rdev::{Event, EventType, Key};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, Emitter};
+
+use crate::{KeyEvent, LayerEvent, SharedLayout};
+
+pub const MACOS_GLOBAL_PATH: &str = "macos-global";
+
+fn rdev_to_evdev(key: Key) -> Option<u16> {
+    Some(match key {
+        Key::KeyA => 30, Key::KeyB => 48, Key::KeyC => 46, Key::KeyD => 32,
+        Key::KeyE => 18, Key::KeyF => 33, Key::KeyG => 34, Key::KeyH => 35,
+        Key::KeyI => 23, Key::KeyJ => 36, Key::KeyK => 37, Key::KeyL => 38,
+        Key::KeyM => 50, Key::KeyN => 49, Key::KeyO => 24, Key::KeyP => 25,
+        Key::KeyQ => 16, Key::KeyR => 19, Key::KeyS => 31, Key::KeyT => 20,
+        Key::KeyU => 22, Key::KeyV => 47, Key::KeyW => 17, Key::KeyX => 45,
+        Key::KeyY => 21, Key::KeyZ => 44,
+        Key::Num1 => 2, Key::Num2 => 3, Key::Num3 => 4, Key::Num4 => 5,
+        Key::Num5 => 6, Key::Num6 => 7, Key::Num7 => 8, Key::Num8 => 9,
+        Key::Num9 => 10, Key::Num0 => 11,
+        Key::Return => 28,
+        Key::Escape => 1,
+        Key::Backspace => 14,
+        Key::Tab => 15,
+        Key::Space => 57,
+        Key::Minus => 12,
+        Key::Equal => 13,
+        Key::LeftBracket => 26,
+        Key::RightBracket => 27,
+        Key::BackSlash => 43,
+        Key::SemiColon => 39,
+        Key::Quote => 40,
+        Key::BackQuote => 41,
+        Key::Comma => 51,
+        Key::Dot => 52,
+        Key::Slash => 53,
+        Key::F1 => 59, Key::F2 => 60, Key::F3 => 61, Key::F4 => 62,
+        Key::F5 => 63, Key::F6 => 64, Key::F7 => 65, Key::F8 => 66,
+        Key::F9 => 67, Key::F10 => 68, Key::F11 => 87, Key::F12 => 88,
+        Key::Insert => 110,
+        Key::Home => 102,
+        Key::PageUp => 104,
+        Key::Delete => 111,
+        Key::End => 107,
+        Key::PageDown => 109,
+        Key::RightArrow => 106,
+        Key::LeftArrow => 105,
+        Key::DownArrow => 108,
+        Key::UpArrow => 103,
+        Key::ControlLeft => 29,
+        Key::ControlRight => 97,
+        Key::ShiftLeft => 42,
+        Key::ShiftRight => 54,
+        Key::Alt => 56,
+        Key::AltGr => 100,
+        Key::MetaLeft => 125,
+        Key::MetaRight => 126,
+        Key::CapsLock => 58,
+        _ => return None,
+    })
+}
+
+type HoldTimers = Arc<Mutex<HashMap<u16, std::time::Instant>>>;
+
+static STARTED: AtomicBool = AtomicBool::new(false);
+
+pub fn start_capture(app: AppHandle, shared: SharedLayout) -> bool {
+    if STARTED.swap(true, Ordering::SeqCst) {
+        info!("macOS capture already running");
+        return false;
+    }
+
+    let timers: HoldTimers = Arc::new(Mutex::new(HashMap::new()));
+
+    {
+        let app = app.clone();
+        let shared = Arc::clone(&shared);
+        let timers = Arc::clone(&timers);
+        std::thread::spawn(move || loop {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let data = shared.read().unwrap();
+            let tap_term = std::time::Duration::from_millis(data.tapping_term_ms.max(50));
+            let mut t = timers.lock().unwrap();
+            t.retain(|&pos, pressed_at| {
+                if pressed_at.elapsed() >= tap_term {
+                    if let Some(layer) = data.pos_to_layer.get(&pos) {
+                        let _ = app.emit("layer-event", LayerEvent { layer: layer.clone() });
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+        });
+    }
+
+    std::thread::spawn(move || {
+        info!("rdev listener starting on macOS");
+        let callback = move |event: Event| {
+            let (key, pressed) = match event.event_type {
+                EventType::KeyPress(k) => (k, true),
+                EventType::KeyRelease(k) => (k, false),
+                _ => return,
+            };
+            let Some(code) = rdev_to_evdev(key) else { return };
+
+            let data = shared.read().unwrap();
+            let Some(&pos) = data.code_to_pos.get(&code) else { return };
+
+            let _ = app.emit("key-event", KeyEvent { pos, pressed });
+
+            if data.pos_to_layer.contains_key(&pos) {
+                let mut t = timers.lock().unwrap();
+                if pressed {
+                    t.insert(pos, std::time::Instant::now());
+                } else {
+                    t.remove(&pos);
+                    let _ = app.emit(
+                        "layer-event",
+                        LayerEvent { layer: data.default_layer.clone() },
+                    );
+                }
+            }
+        };
+
+        if let Err(err) = rdev::listen(callback) {
+            warn!("rdev::listen exited with error: {:?}", err);
+            STARTED.store(false, Ordering::SeqCst);
+        }
+    });
+
+    true
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    k0_keyboard_overlay_lib::run();
+    k0_lib::run();
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
-	"productName": "k0-keyboard-overlay",
+	"productName": "k0",
 	"version": "0.3.0",
-	"identifier": "com.k0-keyboard-overlay.app",
+	"identifier": "com.k0.app",
 	"build": {
 		"beforeBundleCommand": "pnpm run build",
 		"beforeDevCommand": "pnpm run dev",
@@ -14,7 +14,7 @@
 		"macOSPrivateApi": true,
 		"windows": [
 			{
-				"title": "k0-keyboard-overlay",
+				"title": "k0",
 				"width": 800,
 				"height": 380,
 				"transparent": true,
@@ -41,7 +41,12 @@
 			"icons/128x128@2x.png",
 			"icons/icon.icns",
 			"icons/icon.ico"
-		]
+		],
+		"macOS": {
+			"entitlements": "entitlements.plist"
+		},
+		"iOS": {},
+		"android": {}
 	},
 	"plugins": {
 		"logger": {

--- a/src/components/KeyButton/index.tsx
+++ b/src/components/KeyButton/index.tsx
@@ -9,7 +9,6 @@ interface Props {
 	shifted?: string;
 	pressed?: boolean;
 	layerHeld?: boolean;
-	onClick?: () => void;
 }
 
 function KeyText({ y, cls, label }: { y: number; cls: string; label: string }) {
@@ -42,7 +41,6 @@ export function KeyButton({
 	shifted,
 	pressed,
 	layerHeld,
-	onClick,
 }: Props) {
 	const cls = [
 		"key",
@@ -54,12 +52,7 @@ export function KeyButton({
 		.join(" ");
 
 	return (
-		<g
-			transform={`translate(${x}, ${y})`}
-			class={cls}
-			onClick={onClick}
-			style={onClick ? "cursor:pointer" : undefined}
-		>
+		<g transform={`translate(${x}, ${y})`} class={cls}>
 			<rect
 				rx={6}
 				ry={6}

--- a/src/components/KeyButton/style.css
+++ b/src/components/KeyButton/style.css
@@ -1,13 +1,16 @@
 .key rect.key {
 	fill: var(--k0-key-fill, #45475a);
 	stroke: var(--k0-key-stroke, #585b70);
-	transition: fill var(--k0-key-transition-duration, 60ms) var(--k0-key-transition-easing, ease-out),
-		stroke var(--k0-key-transition-duration, 60ms) var(--k0-key-transition-easing, ease-out);
+	transition: fill var(--k0-key-transition-duration, 60ms)
+		var(--k0-key-transition-easing, ease-out), stroke
+		var(--k0-key-transition-duration, 60ms)
+		var(--k0-key-transition-easing, ease-out);
 }
 .key rect.side {
 	fill: var(--k0-key-fill, #45475a);
 	filter: brightness(75%);
-	transition: fill var(--k0-key-transition-duration, 60ms) var(--k0-key-transition-easing, ease-out);
+	transition: fill var(--k0-key-transition-duration, 60ms)
+		var(--k0-key-transition-easing, ease-out);
 }
 .key text {
 	fill: var(--k0-key-text, #cdd6f4);
@@ -15,7 +18,8 @@
 	font-size: 11px;
 	text-anchor: middle;
 	dominant-baseline: middle;
-	transition: fill var(--k0-key-transition-duration, 60ms) var(--k0-key-transition-easing, ease-out);
+	transition: fill var(--k0-key-transition-duration, 60ms)
+		var(--k0-key-transition-easing, ease-out);
 }
 .key text.hold,
 .key text.shifted {

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -13,6 +13,11 @@ import {
 	svgFileName,
 	yamlFileName,
 } from "../../lib/keymapStore";
+import {
+	inputAccess,
+	openInputMonitoringSettings,
+	requestInputAccess,
+} from "../../lib/permissions";
 import { invoke } from "../../lib/tauri";
 import { THEMES, TRANSITIONS, applyTheme } from "../../lib/themes";
 import "./style.css";
@@ -25,6 +30,7 @@ interface DeviceInfo {
 
 interface Props {
 	open: boolean;
+	initialTab?: string;
 	onClose: () => void;
 	onDevicesSelect: (paths: string[]) => void;
 	activeDevices: string[];
@@ -35,8 +41,13 @@ interface Props {
 const TABS = ["Devices", "Theme", "Input", "Import/Export", "Console"] as const;
 type Tab = (typeof TABS)[number];
 
+function isTab(v: string | undefined): v is Tab {
+	return !!v && (TABS as readonly string[]).includes(v);
+}
+
 export function Settings({
 	open,
+	initialTab,
 	onClose,
 	onDevicesSelect,
 	activeDevices,
@@ -54,7 +65,10 @@ export function Settings({
 	const consoleEndRef = useRef<HTMLDivElement>(null);
 	const logs = useComputed(() => consoleLogs.value);
 
-	// Fetch devices when panel opens
+	useEffect(() => {
+		if (open && isTab(initialTab)) setTab(initialTab);
+	}, [open, initialTab]);
+
 	useEffect(() => {
 		if (!open) return;
 		invoke<DeviceInfo[]>("list_devices")
@@ -62,9 +76,8 @@ export function Settings({
 			.catch((e) => console.error("list_devices:", e));
 	}, [open]);
 
-	// Auto-scroll console on new log entries (signal-reactive)
 	useSignalEffect(() => {
-		void consoleLogs.value; // subscribe to signal
+		void consoleLogs.value;
 		if (tab === "Console") {
 			consoleEndRef.current?.scrollIntoView({ behavior: "smooth" });
 		}
@@ -120,9 +133,10 @@ export function Settings({
 			<div class="panel-body">
 				{tab === "Devices" && (
 					<div class="panel-section">
+						<PermissionStatus />
 						<p class="muted">
-							Select which /dev/input/event* nodes to capture. Interfaces
-							sharing a unique ID are grouped.
+							Select which devices to capture. Interfaces sharing a unique ID
+							are grouped.
 						</p>
 						<div class="device-list">
 							{devices.length === 0 ? (
@@ -436,17 +450,13 @@ function ImportExportPanel() {
 		<div class="panel-section panel-section--row">
 			<div class="panel-col">
 				<span class="panel-col-label">Import</span>
-				<div
+				<button
+					type="button"
 					class={`drop-zone ${dragging ? "drop-zone--active" : ""}`}
 					onDrop={handleDrop}
 					onDragOver={handleDragOver}
 					onDragLeave={() => setDragging(false)}
 					onClick={() => fileRef.current?.click()}
-					onKeyDown={(e) => {
-						if (e.key === "Enter") fileRef.current?.click();
-					}}
-					role="button"
-					tabIndex={0}
 				>
 					<span class="drop-zone-icon">📂</span>
 					<span class="drop-zone-text">
@@ -461,7 +471,7 @@ function ImportExportPanel() {
 						onChange={handleFileInput}
 						class="drop-zone-input"
 					/>
-				</div>
+				</button>
 				{importError.value && <p class="import-error">{importError.value}</p>}
 				<div class="import-status">
 					<div class="import-file">
@@ -508,5 +518,39 @@ function ImportExportPanel() {
 				</div>
 			</div>
 		</div>
+	);
+}
+
+function PermissionStatus() {
+	const status = useComputed(() => inputAccess.value);
+	const value = status.value;
+
+	if (value === "unsupported") return null;
+
+	const labels: Record<string, { text: string; tone: string }> = {
+		granted: { text: "Input Monitoring granted", tone: "success" },
+		denied: { text: "Input Monitoring denied", tone: "attention" },
+		unknown: { text: "Input Monitoring not yet requested", tone: "attention" },
+	};
+	const { text, tone } = labels[value] ?? labels.unknown;
+
+	return (
+		<fieldset class={tone}>
+			<legend>macOS permission</legend>
+			<p>{text}</p>
+			{value !== "granted" && (
+				<>
+					<button type="button" onClick={() => void requestInputAccess()}>
+						Request permission
+					</button>
+					<button
+						type="button"
+						onClick={() => void openInputMonitoringSettings()}
+					>
+						Open System Settings
+					</button>
+				</>
+			)}
+		</fieldset>
 	);
 }

--- a/src/components/Settings/style.css
+++ b/src/components/Settings/style.css
@@ -318,6 +318,11 @@ details.device-group.partial {
 	cursor: pointer;
 	transition: border-color 150ms, background 150ms;
 	position: relative;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	width: 100%;
+	text-align: center;
 }
 .drop-zone:hover,
 .drop-zone--active {

--- a/src/lib/mock.ts
+++ b/src/lib/mock.ts
@@ -42,12 +42,21 @@ function emit(event: string, payload: unknown) {
 
 // --- Tauri API stubs ---
 
+let mockInputAccess: "granted" | "denied" | "unknown" | "unsupported" =
+	"unsupported";
+
 export async function invoke(cmd: string, _args?: unknown): Promise<unknown> {
 	if (cmd === "list_devices") {
 		return [{ path: "/dev/input/mock0", name: "Mock Keyboard", uniq: "mock" }];
 	}
 	if (cmd === "start_capture") return null;
 	if (cmd === "update_layout") return null;
+	if (cmd === "check_input_access") return mockInputAccess;
+	if (cmd === "request_input_access_cmd") {
+		if (mockInputAccess === "unknown") mockInputAccess = "granted";
+		return mockInputAccess;
+	}
+	if (cmd === "open_input_monitoring_settings") return null;
 	console.debug(`[mock] invoke("${cmd}")`, _args);
 	return null;
 }
@@ -148,6 +157,10 @@ const simulator = {
 			simulator.releaseLayer(label);
 			await delay(200);
 		}
+	},
+
+	setInputAccess(state: "granted" | "denied" | "unknown" | "unsupported") {
+		mockInputAccess = state;
 	},
 };
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,52 @@
+import { signal } from "@preact/signals";
+import { invoke } from "./tauri";
+
+export type InputAccessStatus =
+	| "granted"
+	| "denied"
+	| "unknown"
+	| "unsupported";
+
+export const inputAccess = signal<InputAccessStatus>("unsupported");
+
+const POLL_INTERVAL_MS = 2000;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+async function refresh() {
+	try {
+		inputAccess.value = await invoke<InputAccessStatus>("check_input_access");
+	} catch {
+		inputAccess.value = "unsupported";
+	}
+}
+
+export function startInputAccessPolling() {
+	if (pollTimer) return;
+	void refresh();
+	pollTimer = setInterval(refresh, POLL_INTERVAL_MS);
+}
+
+export function stopInputAccessPolling() {
+	if (pollTimer) {
+		clearInterval(pollTimer);
+		pollTimer = null;
+	}
+}
+
+export async function requestInputAccess(): Promise<InputAccessStatus> {
+	try {
+		const next = await invoke<InputAccessStatus>("request_input_access_cmd");
+		inputAccess.value = next;
+		return next;
+	} catch {
+		return "unsupported";
+	}
+}
+
+export async function openInputMonitoringSettings(): Promise<void> {
+	try {
+		await invoke("open_input_monitoring_settings");
+	} catch (err) {
+		console.error("open_input_monitoring_settings:", err);
+	}
+}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -10,6 +10,11 @@ import {
 	parsedLayout,
 	posToLayerStrKeys,
 } from "../../lib/keymapStore";
+import {
+	inputAccess,
+	startInputAccessPolling,
+	stopInputAccessPolling,
+} from "../../lib/permissions";
 import { invoke, listen } from "../../lib/tauri";
 import { loadSavedTheme } from "../../lib/themes";
 
@@ -26,6 +31,7 @@ function getSavedDevices(): string[] {
 
 export function Home() {
 	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [settingsTab, setSettingsTab] = useState<string | undefined>();
 	const [activeDevices, setActiveDevices] = useState<string[]>(getSavedDevices);
 	const [tappingTermMs, setTappingTermMs] = useState<number>(() => {
 		const saved =
@@ -66,6 +72,8 @@ export function Home() {
 			});
 		}
 
+		startInputAccessPolling();
+
 		const unlistenKey = listen<{ pos: number; pressed: boolean }>(
 			"key-event",
 			({ payload }) => {
@@ -84,6 +92,7 @@ export function Home() {
 		);
 
 		return () => {
+			stopInputAccessPolling();
 			unlistenKey.then((fn) => fn());
 			unlistenLayer.then((fn) => fn());
 		};
@@ -116,21 +125,36 @@ export function Home() {
 	}
 
 	const parsed = parsedLayout.value;
+	const access = inputAccess.value;
+	const showPermPill = access === "denied" || access === "unknown";
+
+	function openSettings(tab?: string) {
+		setSettingsTab(tab);
+		setSettingsOpen(true);
+	}
 
 	return (
 		<div class="home-root">
 			<div class="top-row">
+				{showPermPill && (
+					<button
+						type="button"
+						class="perm-pill attention"
+						onClick={() => openSettings("Devices")}
+					>
+						⚠ Permission required
+					</button>
+				)}
 				<svg
 					class={`cog-key ${settingsOpen ? "cog-active" : ""}`}
 					viewBox="-26 -26 52 52"
-					onClick={() => setSettingsOpen((v) => !v)}
+					onClick={() => openSettings()}
 					onKeyDown={(e) => {
-						if (e.key === "Enter") setSettingsOpen((v) => !v);
+						if (e.key === "Enter") openSettings();
 					}}
 					aria-label="Toggle settings panel"
-					role="button"
-					tabIndex={0}
 				>
+					<title>Toggle settings panel</title>
 					<KeyButton pos={-1} x={0} y={0} tap="⚙" />
 				</svg>
 			</div>
@@ -140,6 +164,7 @@ export function Home() {
 					viewBox={parsed.viewBox}
 					xmlns="http://www.w3.org/2000/svg"
 				>
+					<title>Keyboard layout</title>
 					{parsed.keys.map(({ pos, x, y }) => {
 						const labels = layerLabels?.get(pos);
 						return (
@@ -163,6 +188,7 @@ export function Home() {
 			)}
 			<Settings
 				open={settingsOpen}
+				initialTab={settingsTab}
 				onClose={() => setSettingsOpen(false)}
 				onDevicesSelect={handleDevicesSelect}
 				activeDevices={activeDevices}

--- a/src/pages/Home/style.css
+++ b/src/pages/Home/style.css
@@ -10,8 +10,14 @@
 .top-row {
 	display: flex;
 	justify-content: flex-end;
+	align-items: center;
+	gap: 6px;
 	width: 100%;
 	flex: 0 0 auto;
+}
+
+.perm-pill {
+	background: var(--bg-default);
 }
 
 .keymap-svg {


### PR DESCRIPTION
Restores macOS keyboard event capture (broken in 4c6947f when the backend was rewritten around Linux evdev) by adding a macOS-specific module using rdev for CGEventTap-based global capture. The wire protocol with the frontend (key-event/layer-event, evdev key codes) is preserved so no capture-side frontend changes were needed.

Backend
- src-tauri/src/macos.rs: rdev::listen on a dedicated thread, hold-tap watcher, rdev::Key -> Linux evdev u16 lookup matching src/lib/labelTable.ts
- list_devices returns a synthetic "macos-global" device on macOS
- start_capture idempotent (single global tap)
- request_input_access called from Builder::setup (canonical Tauri hook, matches the original a66da1d behavior)
- new commands: check_input_access, request_input_access_cmd, open_input_monitoring_settings
- Info.plist usage descriptions for NSInputMonitoringUsageDescription and NSAppleEventsUsageDescription; entitlements.plist for signed distribution builds

Permission UX
- inputAccess signal polled every 2s (src/lib/permissions.ts)
- Warning pill next to cog when permission denied/unknown, clicking opens Settings on the Devices tab
- Settings > Devices shows a status fieldset with Request / Open System Settings buttons (matcha utility classes, minimal custom CSS)
- mock.ts exposes setInputAccess for ?mock visual testing

App rename
- k0-keyboard-overlay -> k0 across productName, identifier, window title, Cargo package + lib name, main.rs entry point

Drive-by a11y fixes (pre-existing biome errors blocking the README's validation chain)
- KeyButton: remove dead onClick prop
- Home: add <title> elements to SVGs
- Settings: drop-zone div -> button (semantic, keyboard-accessible)
- KeyButton/style.css: biome auto-formatted

Fixes user report: "while it can launch on osx it seems to be monitoring linux specific events and does not detect anything here"

Validation
- pnpm biome check src/  -> 0 errors
- cargo check            -> 0 warnings
- pnpm run build         -> ok
- pnpm tauri build       -> .app + .dmg bundled
- ?mock visual smoke test via Playwright (all perm states verified)