### PR TITLE
chore: bump version → 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
 		"typescript": "^5.6.3",
 		"vite": "^5.3.3"
 	},
-	"version": "0.3.0"
+	"version": "0.3.1"
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "k0",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"identifier": "com.k0.app",
 	"build": {
 		"beforeBundleCommand": "pnpm run build",


### PR DESCRIPTION
Per README release flow (chore/bump-vX.Y.Z → PR → merge → tag).

Bumps:
- package.json: 0.3.0 → 0.3.1
- src-tauri/tauri.conf.json: 0.3.0 → 0.3.1

After merge: tag v0.3.1 on main → release.yml triggers.