### PR TITLE
chore: pre-approve biome + esbuild build scripts for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - '@biomejs/biome'
+  - esbuild


### PR DESCRIPTION
## Why

The release.yml workflow uses `pnpm/action-setup@v4` with `version: latest`. Between v0.3.0 (2026-04-24, CI green) and v0.3.1 (2026-06-10, CI red) the externally-resolved pnpm `latest` rolled forward into the 11.x line, which treats unapproved postinstall/build scripts as a hard install failure under `--frozen-lockfile`.

Both attempts to release v0.3.1 failed identically at "Install frontend dependencies" on every matrix runner:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:
@biomejs/biome@1.9.4, esbuild@0.21.5, esbuild@0.27.7
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Error: Process completed with exit code 1.
```

Reproduced on:
- run [27266039288](https://github.com/seppulcro/k0/actions/runs/27266039288) (first attempt)
- run [27266922690](https://github.com/seppulcro/k0/actions/runs/27266922690) (re-tag after PR #13)

## Fix

Per [pnpm 11 docs](https://pnpm.io/settings), the allow-list lives in `pnpm-workspace.yaml` under `onlyBuiltDependencies`. Both packages ship prebuilt native binaries via their postinstall scripts:
- `@biomejs/biome` — Rust binary for the language server / formatter
- `esbuild` — native Go binary for the transpiler used by Vite

Both are required at install time for CI's `pnpm run build` step.

## Verification

- Local install with pnpm 11.4 + `--frozen-lockfile` exits 0
- After merge: re-tag v0.3.1 on main → release.yml will retry and should produce `.app`/`.dmg`/`.deb`/`.msi`/`.AppImage` artifacts

## Scope

CI-only chore. No source code or build-output behavior changes. The macOS fix landed in PR #12; the version bump in PR #13.