### PR TITLE
chore: add direnv .envrc + .env.example for contributor env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env (gitignored) and fill in values.
+# Auto-loaded by direnv on `cd` into this repo, if direnv is installed.
+
+# GitHub Personal Access Token consumed by the opencode github MCP server
+# (https://github.com/github/github-mcp-server). Scopes needed:
+#   - repo
+#   - workflow
+#   - read:org
+#   - read:packages
+#
+# Generate at: https://github.com/settings/tokens/new
+# Use "No expiration" for personal dev machines; rotate periodically.
+#
+# Leave commented if you don't use opencode + the github MCP.
+# GITHUB_PERSONAL_ACCESS_TOKEN=ghp_your_token_here

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+# Loads .env (gitignored) into the environment when you `cd` into this repo.
+# Requires direnv: https://direnv.net
+#
+# First-time setup:
+#   1. brew install direnv  (or your platform's equivalent)
+#   2. Add to your shell rc:  eval "$(direnv hook zsh)"   (or bash/fish equivalent)
+#   3. cp .env.example .env, fill in values
+#   4. direnv allow      (one-time approval per machine)
+#
+# Without direnv, just `source .env` manually or export variables in your shell.
+dotenv_if_exists

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ playwright-report/
 tests/screenshots/
 tmp-video/
 .playwright-mcp/
+
+# Local env / direnv overrides (committed: .env.example, .envrc)
+.env
+.env.local
+.envrc.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,27 @@ pnpm tauri dev       # hot reload — Tauri + Vite
 Browser mock mode (no Tauri runtime needed) — open
 `http://localhost:5173?mock` and use `window.__k0mock` to drive the UI.
 
+## Environment variables
+
+Local secrets (e.g. a GitHub PAT for opencode's github MCP) live in a
+gitignored `.env`. The contract is documented in
+[`.env.example`](./.env.example) — copy it to `.env` and fill in what
+you need:
+
+```bash
+cp .env.example .env
+$EDITOR .env
+```
+
+If you have [direnv](https://direnv.net) installed (with
+`eval "$(direnv hook zsh)"` in your shell rc), `cd`ing into this repo
+auto-loads `.env` via the committed [`.envrc`](./.envrc). One-time
+approval per machine: `direnv allow`. Without direnv, just `source .env`
+yourself.
+
+Nothing in the k0 source code itself requires environment variables —
+this contract exists only for surrounding tooling like opencode.
+
 ## Pre-commit / pre-push hooks
 
 `pnpm install` installs [lefthook](https://lefthook.dev) hooks via the


### PR DESCRIPTION
## Why

Surrounding tooling (notably [opencode](https://opencode.ai)'s [github MCP server](https://github.com/github/github-mcp-server)) consumes a `GITHUB_PERSONAL_ACCESS_TOKEN` env var. Contributors should be able to plug their own token in without:

- leaking it into the repo
- needing me to ship a token
- coupling to a specific shell or version manager

## What

Standard direnv contract — committed scaffold, gitignored secrets:

| File | Status | Purpose |
|---|---|---|
| `.envrc` | committed | Calls `dotenv_if_exists`; safe to ignore if you don't have direnv |
| `.env.example` | committed | Documents `GITHUB_PERSONAL_ACCESS_TOKEN` scopes + where to generate |
| `.env`, `.env.local`, `.envrc.local` | gitignored | Real values, never committed |
| `CONTRIBUTING.md` | updated | New "Environment variables" section with/without-direnv flow |

## Important

- k0's **source code** uses zero env vars (no `process.env`, no `std::env`). This contract exists purely for **surrounding tooling**, not the app itself
- direnv is **not** a build prerequisite. The docs work as plain shell instructions for anyone who doesn't have it
- Bridges the gap to per-identity multi-repo workflows (different PAT per repo) without forcing them on solo users today

## Verification

- `pnpm biome check src/` → 0 errors, 0 warnings
- No source code touched

## Scope

Docs + contract only. Closes the loop on the per-project env-var question raised during the modernize PR (#21) review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines with instructions for configuring environment variables and optional direnv integration.

* **Chores**
  * Added environment configuration templates and setup files for local development environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->